### PR TITLE
Adding Reference to Promregator

### DIFF
--- a/content/docs/operating/integrations.md
+++ b/content/docs/operating/integrations.md
@@ -24,6 +24,7 @@ For service discovery mechanisms not natively supported by Prometheus,
 
  * [Docker Swarm](https://github.com/ContainerSolutions/prometheus-swarm-discovery)
  * [Scaleway](https://github.com/scaleway/prometheus-scw-sd)
+ * [Promregator](https://github.com/promregator/promregator) (discovery and scraping for Cloud Foundry applications)
 
 ## Remote Endpoints and Storage
 


### PR DESCRIPTION
Promregator provides discovery and facilitates scraping of Cloud-Foundry-based applications. Amongst another mechanism, it also uses the file-based service discovery approach to communicate the result of discovery to Prometheus. 
After some time of incubation of the project, I (as the maintainer of Promregator) would like to ask for referencing the project in Prometheus' docs.

@brian-brazil ping to you, as requested in CONTRIBUTING.md.
DCO-Signed-Off-By is in place.